### PR TITLE
Handle Android RN 0.47 breaking change

### DIFF
--- a/android/src/main/java/im/shimo/react/cookie/CookieManagerPackage.java
+++ b/android/src/main/java/im/shimo/react/cookie/CookieManagerPackage.java
@@ -24,7 +24,7 @@ public class CookieManagerPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Method createJSModules was removed from RN 0.47. Which leads to compilation error due to @override annotation. This method can be removed right now.