### PR TITLE
RN 0.60+ Linking Library Fixed

### DIFF
--- a/react-native-cookie.podspec
+++ b/react-native-cookie.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = 'shimohq'
+  s.homepage     = 'homepage'
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/shimohq/react-native-cookie.git", :tag => "v#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
add this in pod file =>pod 'react-native-cookie', :path => '../node_modules/react-native-cookie'
 run pod install ,and then this will fix the linking error in RN 0.60+